### PR TITLE
Refactory ETL class

### DIFF
--- a/nikon_ETL.py
+++ b/nikon_ETL.py
@@ -148,7 +148,7 @@ def rscript_avm(r, toolid, starttime, endtime):
 
 
 class Base:
-    """docstring for DB
+    """docstring for Base
     """
     def __init__(self):
         super(Base, self).__init__()

--- a/nikon_ETL.py
+++ b/nikon_ETL.py
@@ -150,6 +150,7 @@ def rscript_avm(r, toolid, starttime, endtime):
 class Base:
     """docstring for Base
     """
+
     def __init__(self):
         super(Base, self).__init__()
         pass
@@ -513,7 +514,8 @@ class ETL(Base):
             update_endtime=update_endtime.strftime('%Y-%m-%d %H:%M:%S')
         )
         msg = decode_cmd_out(ret[toolid])
-        print('args: {}, stdout: {}'.format(msg.args, msg.stdout.replace('\r', '')))
+        print('args: {}, stdout: {}'.format(
+            msg.args, msg.stdout.replace('\r', '')))
         print('return code: {}, stderr: {}'.format(msg.returncode, msg.stderr))
         print('{0} ROT End {0}'.format("**" * 3))
         return msg
@@ -529,7 +531,8 @@ class ETL(Base):
             update_endtime=update_endtime.strftime('%Y-%m-%d %H:%M:%S')
         )
         msg = decode_cmd_out(ret[toolid])
-        print('args: {}, stdout: {}'.format(msg.args, msg.stdout.replace('\r', '')))
+        print('args: {}, stdout: {}'.format(
+            msg.args, msg.stdout.replace('\r', '')))
         print('return code: {}, stderr: {}'.format(msg.returncode, msg.stderr))
         print('{0} ROT Mea End {0}'.format("**" * 3))
         return msg

--- a/nikon_ETL.py
+++ b/nikon_ETL.py
@@ -167,7 +167,6 @@ class Base:
         else:
             return {'ret': True, 'add': add_cols, 'del': del_cols}
 
-    @classmethod
     def clean_endtimedata(self, endtime_data):
         insert_data = []
         logintime = datetime.now()
@@ -176,7 +175,6 @@ class Base:
             insert_data.append(tuple(d.values()))
         return insert_data
 
-    @classmethod
     def clean_edcdata(self, edc_data, schemacolnames):
         datas = []
         edc_columns = list(edc_data[0].keys())
@@ -191,7 +189,6 @@ class Base:
         print('Insert count: {}'.format(len(datas)))
         return datas
 
-    @classmethod
     def clean_schemacolnames(self, schemacolnames):
         return [column[0].upper()
                 for column in schemacolnames]
@@ -207,6 +204,13 @@ class ETL(Base):
         self.fdc_oracle = nikon.FdcOracle()
         self.eda_oracle = nikon.EdaOracle()
         self.toolid = toolid
+
+    def get_aplastendtime(self, apname):
+        row = self.fdc_psql.get_lastendtime(
+            toolid=self.toolid,
+            apname=apname
+        )
+        return row
 
     @asyncio.coroutine
     def insert(self, toolid):
@@ -497,14 +501,6 @@ class ETL(Base):
                     )
                 except Exception as e:
                     raise e
-
-    @classmethod
-    def get_aplastendtime(self, apname):
-        row = self.fdc_psql.get_lastendtime(
-            toolid=self.toolid,
-            apname=apname
-        )
-        return row
 
     @classmethod
     def execute_r_rot(self, toolid, update_starttime, update_endtime):

--- a/nikon_ETL.py
+++ b/nikon_ETL.py
@@ -147,15 +147,31 @@ def rscript_avm(r, toolid, starttime, endtime):
     return rprocess
 
 
-class ETL:
+class DBbase:
+    """docstring for DB
+    """
+    def __init__(self):
+        super(DBbase, self).__init__()
+        self.fdc_psql = nikon.FdcPGSQL()
+        self.fdc_oracle = nikon.FdcOracle()
+        self.eda_oracle = nikon.EdaOracle()
+
+
+    @classmethod
+    def get_aplastendtime(self, apname):
+        row = self.fdc_psql.get_lastendtime(
+            toolid=self.toolid,
+            apname=apname
+        )
+        return row
+
+
+class ETL(DBbase):
     """docstring for ETL
     """
 
     def __init__(self, toolid):
         super(ETL, self).__init__()
-        self.fdc_psql = nikon.FdcPGSQL()
-        self.fdc_oracle = nikon.FdcOracle()
-        self.eda_oracle = nikon.EdaOracle()
         self.toolid = toolid
 
     def column_state(self, edc, schema):
@@ -243,6 +259,7 @@ class ETL:
             except Exception as e:
                 raise e
 
+    @classmethod
     def clean_endtimedata(self, endtime_data):
         insert_data = []
         logintime = datetime.now()
@@ -501,13 +518,7 @@ class ETL:
         print('{0} ROT Mea End {0}'.format("**" * 3))
         return msg
 
-    def get_aplastendtime(self, apname, *args, **kwargs):
-        row = self.fdc_psql.get_lastendtime(
-            toolid=self.toolid,
-            apname=apname
-        )
-        return row
-
+    @classmethod
     def clean_edcdata(self, edc_data, schemacolnames):
         datas = []
         edc_columns = list(edc_data[0].keys())
@@ -522,22 +533,16 @@ class ETL:
         print('Insert count: {}'.format(len(datas)))
         return datas
 
+    @classmethod
     def clean_schemacolnames(self, schemacolnames):
         return [column[0].upper()
                 for column in schemacolnames]
-
-    @logger.patch
-    def status(self):
-        pass
-
-    def __str__(self):
-        pass
 
 
 @call_lazylog
 def etlmain(*args, **kwargs):
     etl = ETL(toolid='NIKON')
-    # etl.etl(apname='EDC_Import')
+    etl.etl(apname='EDC_Import')
     etl.rot(apname='ROT_Transform')
     # etl.avm(apname='AVM_Process')
 


### PR DESCRIPTION
將 ETL class 做了一些重構，主要是將對資料的清理等可以獨立於資料庫或是流程的操作獨立獨立為一個新的 Base class, 另外因為 r 的呼叫尚未很多，因此採取用 classmethod 的 decorate 方式可以讓外部呼叫。

這樣做法目的為了方便測試。